### PR TITLE
Added gexiv2_metadata_from_app1_segment()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ extern {
     pub fn gexiv2_metadata_free(this: *mut GExiv2Metadata);
     pub fn gexiv2_metadata_open_path(this: *mut GExiv2Metadata, path: *const c_char, error: *mut *mut GError) -> c_int;
     pub fn gexiv2_metadata_open_buf(Gthis: *mut GExiv2Metadata, data: *const u8, data_len: c_long, error: *mut *mut GError) -> c_int;
+    pub fn gexiv2_metadata_from_app1_segment(Gthis: *mut GExiv2Metadata, data: *const u8, data_len: c_long, error: *mut *mut GError) -> c_int;
     pub fn gexiv2_metadata_save_file(this: *mut GExiv2Metadata, path: *const c_char, error: *mut *mut GError) -> c_int;
 
     // Image information.


### PR DESCRIPTION
Upstream doc https://gnome.pages.gitlab.gnome.org/gexiv2/docs/gexiv2-Reading-and-writing-metadata.html#gexiv2-metadata-from-app1-segment


I would have a follow-up patch for rexiv2 once this is released. (tested)

See also #6 