### PR TITLE
Update MSRV to 1.63 (from 1.56) due to dependency requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container_image: ["rust:1.56-slim", "rust:slim", "rustlang/rust:nightly-slim"]
+        container_image: ["rust:1.63-slim", "rust:slim", "rustlang/rust:nightly-slim"]
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2023-01-07 - v1.3.0
+  * Update minimum supported Rust version to 1.63.
+
 2022-07-30 - v1.2.0
   * Internal dependency updates.
   * Adopt 2021 language edition.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ Exif, XMP, and IPTC metadata in media files. Only FFI declarations are provided
 here; for a usable Rust library, consider the `rexiv2` crate.
 """
 
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Felix Crux <felixc@felixcrux.com>"]
 license = "GPL-3.0+"
 documentation = "https://felixcrux.com/files/doc/gexiv2_sys/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ links = "gexiv2"
 build = "build.rs"
 
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 
 include = [
   "Cargo.toml",
@@ -35,7 +35,7 @@ include = [
 [dependencies]
 libc = "0.2"
 bitflags = { version = "1.3", optional = true}
-glib-sys = { version = "0.15", optional = true }
+glib-sys = { version = "0.16", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Given that it links to gexiv2, and transitively to Exiv2, gexiv2-sys obviously
 depends on them. These libraries are not bundled with gexiv2-sys: you will need
 to install them separately.
 
-The minimum supported `rustc` version is 1.56.
+The minimum supported `rustc` version is 1.63.
 
 For full instructions on how to get started with gexiv2-sys, including how to
 install the prerequisite dependencies, refer to the [`SETUP`](SETUP.md) file.


### PR DESCRIPTION
...and bump version number as a result.