### PR TITLE
Issue #24 - Add g_error_free() as a re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ include = [
 ]
 
 [dependencies]
+glib-sys = "0.16"
 libc = "0.2"
 bitflags = { version = "1.3", optional = true}
-glib-sys = { version = "0.16", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"
@@ -44,5 +44,5 @@ pkg-config = "0.3"
 tempfile = "3.3"
 
 [features]
-raw-tag-access = ["glib-sys"]
+raw-tag-access = []
 xmp-packet-access = ["bitflags"]

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ enable this feature and gain the `gexiv2_metadata_get_tag_raw` function. Note
 that the return value of this call is a GLib [`GBytes`][gbytes] object, which
 you can convert to a data pointer via GLib’s [`g_bytes_unref_to_data`][unref].
 
-This feature is disabled by default because it introduces a new dependency on
-[`glib-sys`][glib-sys], and consequently on the GLib system library.
-
 **xmp-packet-access**: If you need access to the XML-formatted XMP packet, you
 can enable this feature. It will add the `gexiv2_metadata_generate_xmp_packet`
 and `gexiv2_metadata_get_xmp_packet` calls. Enabling the feature also introduces
@@ -81,7 +78,6 @@ a new dependency on the the [`bitflags`][bitflags] crate.
 
 [gbytes]: http://gtk-rs.org/docs/glib_sys/struct.GBytes.html
 [unref]: http://gtk-rs.org/docs/glib_sys/fn.g_bytes_unref_to_data.html
-[glib-sys]: https://crates.io/crates/glib-sys/
 [bitflags]: https://crates.io/crates/bitflags
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,17 +49,17 @@ pub enum GExiv2PreviewProperties {}
 /// Be sure to free it with [`gexiv2_preview_image_free()`](fn.gexiv2_preview_image_free.html).
 pub enum GExiv2PreviewImage {}
 
+extern crate glib_sys as glib;
+
 /// Container for information about recoverable runtime errors.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GError {
-    /// Part of the program from which the error originated.
-    pub domain: u32,
-    /// Identifier for the error that occurred.
-    pub code: c_int,
-    /// Human-readable description of the problem.
-    pub message: *const c_char,
-}
+///
+/// Be sure to free it with [`g_error_free`](fn.g_error_free.html).
+///
+/// See <https://docs.gtk.org/glib/struct.Error.html>.
+pub type GError = glib::GError;
+
+/// Frees a [`GError`](type.GError.html) and associated resources.
+pub use glib::g_error_free;
 
 /// All the possible orientations for an image.
 #[repr(C)]
@@ -206,9 +206,6 @@ extern "C" {
     pub fn gexiv2_log_use_glib_logging();
 }
 
-
-#[cfg(feature = "raw-tag-access")]
-extern crate glib_sys as glib;
 
 #[cfg(feature = "raw-tag-access")]
 extern "C" {


### PR DESCRIPTION
This actually make glib no longer optional. Maybe `raw-tag-access` can be default as well.

I was wondering if `glib-sys = "*"` wouldn't be better as this currently make me have both 0.16 and 0.17.

What do you think?